### PR TITLE
coordinate: add support for classifiers

### DIFF
--- a/lib/maven/tools/coordinate.rb
+++ b/lib/maven/tools/coordinate.rb
@@ -4,11 +4,19 @@ module Maven
 
       def to_coordinate(line)
         if line =~ /^\s*(jar|pom)\s/
-          
-          group_id, artifact_id, version, second_version = line.sub(/\s*[a-z]+\s+/, '').sub(/#.*/,'').gsub(/\s+/,'').gsub(/['"],/, ':').gsub(/['"]/, '').split(/:/)
+          packaging = line.strip.sub(/\s+.*/, '')
+
+          # Remove packaging, comments and whitespaces
+          sanitized_line = line.sub(/\s*[a-z]+\s+/, '').sub(/#.*/,'').gsub(/\s+/,'')
+
+          # Remove version(s) and quotes to find the group id, artifact id and classifier
+          group_id, artifact_id, classifier = sanitized_line.split(',')[0].gsub(/['"]/, '').split(/:/)
+
+          # Remove the group id, artifact id and classifier to find the version(s)
+          version, second_version = sanitized_line.split(',')[1..-1].join(',').gsub(/['"],/, ':').gsub(/['"]/, '').split(/:/)
           mversion = second_version ? to_version(version, second_version) : to_version(version)
-          extension = line.strip.sub(/\s+.*/, '')
-          "#{group_id}:#{artifact_id}:#{extension}:#{mversion}"
+
+          classifier ? "#{group_id}:#{artifact_id}:#{packaging}:#{classifier}:#{mversion}" : "#{group_id}:#{artifact_id}:#{packaging}:#{mversion}"
         end
       end
 

--- a/spec/coordinate_spec.rb
+++ b/spec/coordinate_spec.rb
@@ -44,4 +44,15 @@ describe Maven::Tools::Coordinate do
     subject.to_coordinate('pom "e:f", "[1.8,1.9.9)"').must_equal "e:f:pom:[1.8,1.9.9)"
     subject.to_coordinate('pom "f:g", ">1.2", "<=2.0"').must_equal "f:g:pom:(1.2,2.0]"
   end
+
+  it 'should support classifiers' do
+    subject.to_coordinate('something "a:b:jdk15"').must_be_nil
+    subject.to_coordinate('#jar "a:b:jdk15"').must_be_nil
+    subject.to_coordinate('jar "a:b:jdk15" # bla').must_equal "a:b:jar:jdk15:[0,)"
+    subject.to_coordinate("pom 'b:c:jdk15', '!2.3.4'").must_equal "b:c:pom:jdk15:(2.3.4,)"
+    subject.to_coordinate('jar "c:d:jdk15", "2.3.4"').must_equal "c:d:jar:jdk15:2.3.4"
+    subject.to_coordinate("jar 'd:e:jdk15', '~>1.8.2'").must_equal "d:e:jar:jdk15:[1.8.2,1.8.99999]"
+    subject.to_coordinate('pom "e:f:jdk15", "[1.8,1.9.9)"').must_equal "e:f:pom:jdk15:[1.8,1.9.9)"
+    subject.to_coordinate('pom "f:g:jdk15", ">1.2", "<=2.0"').must_equal "f:g:pom:jdk15:(1.2,2.0]"
+  end
 end


### PR DESCRIPTION
Allow one to specify a classifier as part of the coordinates. This is especially
useful to refer to test jars for example.

From http://maven.apache.org/pom.html#Maven_Coordinates:

```
classifier: You may occasionally find a fifth element on the coordinate,
and that is the classifier.
[...] Those kinds of projects are displayed as groupId:artifactId:packaging:classifier:version.
```

Testing done: verified that the following Jarfile would be parsed correctly with JBundler:

```
jar 'com.ning.billing:killbill-api', '0.1.48'
jar 'com.ning.billing:killbill-util:tests', '0.1.48'
```

Signed-off-by: Pierre-Alexandre Meyer pierre@ning.com
