### PR TITLE
Remove annoying Ambiguous warning in tests

### DIFF
--- a/lib/maven/tools/artifact.rb
+++ b/lib/maven/tools/artifact.rb
@@ -146,7 +146,7 @@ module Maven
 
       def exclusions
         if key?( :exclusions )
-          self[:exclusions].inspect.gsub( /[\[\]" ]/, '' ).split /,/
+          self[:exclusions].inspect.gsub( /[\[\]" ]/, '' ).split( /,/ )
         end
       end
 

--- a/lib/maven/tools/coordinate.rb
+++ b/lib/maven/tools/coordinate.rb
@@ -122,7 +122,7 @@ module Maven
       end
 
       def snapshot_version( val )
-        if val.match /[a-z]|[A-Z]/ and not val.match /-SNAPSHOT|[${}]/
+        if val.match(/[a-z]|[A-Z]/) && !val.match(/-SNAPSHOT|[${}]/)
           val + '-SNAPSHOT'
         else
           val


### PR DESCRIPTION
in RSpec $VERBOSE is set to true, which generates an annoying warning:

warning: Ambiguous first argument; make sure.

In MRI it reads like:

warning: ambiguous first argument; put parentheses or even spaces
