### PR TITLE
add support for arbitrary licenses in gemspecs

### DIFF
--- a/lib/maven/tools/dsl/project_gemspec.rb
+++ b/lib/maven/tools/dsl/project_gemspec.rb
@@ -44,10 +44,14 @@ module Maven
           end
 
           spec.licenses.each do |l|
-            lic = Maven::Tools::LICENSES[ l.downcase ]
-            @parent.license( :name => lic.short,
-                             :url => lic.url,
-                             :comments => lic.name )
+            if Maven::Tools::LICENSES.include?(l.downcase)
+              lic = Maven::Tools::LICENSES[ l.downcase ]
+              @parent.license( :name => lic.short,
+                               :url => lic.url,
+                               :comments => lic.name )
+            else
+              @parent.license( l )
+            end
           end
           authors = [ spec.authors || [] ].flatten
           emails = [ spec.email || [] ].flatten

--- a/spec/dsl/profile_gemspec_spec.rb
+++ b/spec/dsl/profile_gemspec_spec.rb
@@ -74,4 +74,11 @@ describe Maven::Tools::DSL::ProfileGemspec do
     xml.must_equal( ProfileGemspecFile.read( 'jars_and_poms_include_jars.xml',
                                              'gemspec_spec' ) )
   end
+
+  it 'evals gemspec without previously known license' do
+    subject.new parent, 'unknown_license.gemspec'
+    xml = ""
+    Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
+    xml.must_equal( ProfileGemspecFile.read( 'unknown_license.xml', 'gemspec_spec' ) )
+  end
 end

--- a/spec/dsl/profile_gemspec_spec/unknown_license.gemspec
+++ b/spec/dsl/profile_gemspec_spec/unknown_license.gemspec
@@ -1,0 +1,17 @@
+# -*- mode:ruby -*-
+# -*- coding: utf-8 -*-
+Gem::Specification.new do |s|
+  s.name = 'maven-tools'
+  s.version = '123'
+
+  s.summary = 'helpers for maven related tasks'
+  s.description = 'adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc'
+  s.homepage = 'http://github.com/torquebox/maven-tools'
+
+  s.authors = ['Christian Meier']
+  s.email = ['m.kristian@web.de']
+
+  s.license = 'unknown'
+end
+
+# vim: syntax=Ruby

--- a/spec/dsl/profile_gemspec_spec/unknown_license.xml
+++ b/spec/dsl/profile_gemspec_spec/unknown_license.xml
@@ -1,0 +1,29 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>no_group_id_given</groupId>
+  <artifactId>profile_gemspec_spec</artifactId>
+  <version>0.0.0</version>
+  <name>profile_gemspec_spec</name>
+  <properties>
+    <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
+    <jruby.plugins.version>1.0.7</jruby.plugins.version>
+  </properties>
+  <repositories>
+    <repository>
+      <id>rubygems-releases</id>
+      <url>http://rubygems-proxy.torquebox.org/releases</url>
+    </repository>
+  </repositories>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
+        <configuration>
+          <gemspec>unknown_license.gemspec</gemspec>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/spec/dsl/project_gemspec_spec.rb
+++ b/spec/dsl/project_gemspec_spec.rb
@@ -94,4 +94,11 @@ describe Maven::Tools::DSL::ProjectGemspec do
     xml.must_equal( XmlFile.read( 'extended.xml',
                                   'gemspec_spec' ) )
   end
+
+  it 'evals gemspec with unknown license' do
+    subject.new parent, :name => 'unknown_license.gemspec'
+    xml = ""
+    Maven::Tools::Visitor.new( xml ).accept_project( parent.model )
+    xml.must_equal( XmlFile.read( 'unknown_license.xml', 'gemspec_spec') )
+  end
 end

--- a/spec/dsl/project_gemspec_spec/unknown_license.gemspec
+++ b/spec/dsl/project_gemspec_spec/unknown_license.gemspec
@@ -1,0 +1,17 @@
+# -*- mode:ruby -*-
+# -*- coding: utf-8 -*-
+Gem::Specification.new do |s|
+  s.name = 'maven-tools'
+  s.version = '123'
+
+  s.summary = 'helpers for maven related tasks'
+  s.description = 'adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc'
+  s.homepage = 'http://github.com/torquebox/maven-tools'
+
+  s.authors = ['Christian Meier']
+  s.email = ['m.kristian@web.de']
+
+  s.license = 'unknown'
+end
+
+# vim: syntax=Ruby

--- a/spec/dsl/project_gemspec_spec/unknown_license.xml
+++ b/spec/dsl/project_gemspec_spec/unknown_license.xml
@@ -1,0 +1,55 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>rubygems</groupId>
+  <artifactId>maven-tools</artifactId>
+  <version>123</version>
+  <packaging>gem</packaging>
+  <name>helpers for maven related tasks</name>
+  <url>http://github.com/torquebox/maven-tools</url>
+  <description>adds versions conversion from rubygems to maven and vice versa, ruby DSL for POM (Project Object Model from maven), pom generators, etc</description>
+  <licenses>
+    <license>
+      <name>unknown</name>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <name>Christian Meier</name>
+      <email>m.kristian@web.de</email>
+    </developer>
+  </developers>
+  <scm>
+    <connection>https://github.com/torquebox/maven-tools.git</connection>
+    <url>http://github.com/torquebox/maven-tools</url>
+  </scm>
+  <properties>
+    <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
+    <jruby.plugins.version>1.0.7</jruby.plugins.version>
+  </properties>
+  <repositories>
+    <repository>
+      <id>rubygems-releases</id>
+      <url>http://rubygems-proxy.torquebox.org/releases</url>
+    </repository>
+  </repositories>
+  <build>
+    <extensions>
+      <extension>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-extension</artifactId>
+        <version>${jruby.plugins.version}</version>
+      </extension>
+    </extensions>
+    <directory>${basedir}/pkg</directory>
+    <plugins>
+      <plugin>
+        <groupId>de.saumya.mojo</groupId>
+        <artifactId>gem-maven-plugin</artifactId>
+        <version>${jruby.plugins.version}</version>
+        <configuration>
+          <gemspec>unknown_license.gemspec</gemspec>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Since the latest update, licenses of the form `Apache License (2.0)` would break because 
a match was not found within the `LICENSES` collection. Instead of forcing others to 
pigeonhole themselves into a specific naming convention, or even a specific license, this fix
will bring back support for arbitrary licenses in the gemspecs.
