### PR TITLE
Match #jarfile behavior to #gemfile

### DIFF
--- a/lib/maven/tools/dsl.rb
+++ b/lib/maven/tools/dsl.rb
@@ -335,6 +335,7 @@ module Maven
           warn "DEPRECATED use filename instead"
           file = jfile.file
         end
+        file = ::File.join( basedir, file ) unless ::File.exists?( file )
         dsl = Maven::Tools::DSL::Jarfile.new( @current, file, options[ :skip_lock ] )
 
         # TODO this setup should be part of DSL::Jarfile


### PR DESCRIPTION
This should give #jarfile the same expected behavior as #gemfile L:128 when working with modules in subdirectories. Both might get janky if the root has its own Gem/Jarfile though. Is that an existing issue?

I haven't tested this yet, just proposing the change after hunting down why it would find my Gemfile but not my Jarfile. Still very much a newb.