### PR TITLE
Fixes frozen string bug in gemspec dependencies

### DIFF
--- a/lib/maven/tools/gemspec_dependencies.rb
+++ b/lib/maven/tools/gemspec_dependencies.rb
@@ -57,8 +57,7 @@ module Maven
           _deps( dep.type ) << "rubygems:#{dep.name}:#{to_version( *versions )}"
         end
         @spec.requirements.each do |req|
-          req.sub!( /#.*^/, '' )
-          coord = to_split_coordinate_with_scope( req )
+          coord = to_split_coordinate_with_scope(req.sub(/#.*^/, ''))
           if coord && coord.size > 1
             _deps( :java ) << coord
           end


### PR DESCRIPTION
With newer versions of Ruby gems, the loaded specs are frozen strings, this makes [jbundler to fail](https://github.com/mkristian/jbundler/blob/0.9.2/lib/jbundler/lock_down.rb#L148-L150). This PR treats the spec requirements as immutable.